### PR TITLE
Add Vitest test examples and project documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /node_modules/
+docker-entrypoint.sh
+Dockerfile

--- a/README.md
+++ b/README.md
@@ -1,3 +1,0 @@
-```console
-% vitest run test/sum.test.ts
-```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+## Setup
+
+Please download the required files by following these steps:
+
+```
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/heads/main/Dockerfile
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/heads/main/docker-entrypoint.sh
+chmod 755 docker-entrypoint.sh
+```
+
+Detailed environment setup instructions are described at the beginning of the `Dockerfile`.
+
+```console
+% vitest run test/sum.test.ts
+```

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,0 @@
-let hello: string = "Hello World！";
-console.log(hello);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@types/node": "^22.10.5",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "eslint": "^8.57.1",
@@ -842,6 +843,16 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -4487,6 +4498,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "Apache-2.0",
   "description": "",
   "devDependencies": {
+    "@types/node": "^22.10.5",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "vitest run"
+    "test": "vitest run --silent"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/test/async.test.ts
+++ b/test/async.test.ts
@@ -1,0 +1,60 @@
+/* eslint-disable max-len */
+
+// Reference:
+// https://qiita.com/mori_goq/items/5b01666cff5134f821bd
+
+// Asynchronous function that resolves successfully
+export const fetchDataResolve = () => new Promise((resolve) => {
+  setTimeout(() => {
+    resolve('tarosuke');
+  }, 10);
+});
+
+// Asynchronous function that rejects with an error
+export const fetchDataReject = () => new Promise((_, reject) => {
+  setTimeout(() => {
+    reject(new Error('something bad happened'));
+  }, 10);
+});
+
+describe('verify asynchronous success', () => {
+  it('test 1', () => fetchDataResolve().then((data) => {
+    expect(data).toBe('tarosuke');
+  }));
+
+  it('test 2', () => expect(fetchDataResolve()).resolves.toBe('tarosuke'));
+
+  it('test 3', async () => {
+    await expect(fetchDataResolve()).resolves.toBe('tarosuke');
+  });
+
+  it('test 4', async () => {
+    await expect(fetchDataResolve()).resolves.toBe('tarosuke');
+  });
+});
+
+describe('verify asynchronous failure', () => {
+  it('test 1', () => fetchDataReject().catch((data) => {
+    expect(data.message).toBe('something bad happened');
+  }));
+
+  it('test 2', () => expect(fetchDataReject()).rejects.toThrow('something bad happened'));
+
+  it('test 3', async () => {
+    await expect(fetchDataReject()).rejects.toThrow('something bad happened');
+  });
+
+  it('test 4', async () => {
+    //
+    // Ensure that the assertion is called once
+    // (If the asynchronous function succeeds, the catch block will not be executed and the test will be considered successful, so it is recommended to include this)
+    //
+    expect.assertions(1);
+
+    try {
+      await fetchDataReject();
+    } catch (error: any) {
+      expect(error.message).toBe('something bad happened');
+    }
+  });
+});

--- a/test/concurrent.test.ts
+++ b/test/concurrent.test.ts
@@ -1,10 +1,13 @@
 /* eslint-disable no-console */
 
-// https://pc.atsuhiro-me.net/entry/2022/02/28/163920
-
 //
 // NOTE:
 // `vitest run --silent`: Silent console output from tests
+//
+
+//
+// Reference:
+// https://pc.atsuhiro-me.net/entry/2022/02/28/163920
 //
 
 // eslint-disable-next-line no-promise-executor-return
@@ -14,17 +17,20 @@ beforeAll(async () => {
   await sleep(100);
   console.log('beforeAll() complete.');
 });
-afterAll(async () => {
-  await sleep(100);
-  console.log('afterAll() complete.');
-});
+
 beforeEach(async () => {
   await sleep(100);
   console.log('beforeEach() complete.');
 });
+
 afterEach(async () => {
   await sleep(100);
   console.log('afterEach() complete.');
+});
+
+afterAll(async () => {
+  await sleep(100);
+  console.log('afterAll() complete.');
 });
 
 describe('concurrent suite', () => {
@@ -33,11 +39,13 @@ describe('concurrent suite', () => {
     expect(1).toBe(1);
     console.log('concurrent: test a complete.');
   });
+
   it.concurrent('b', async () => {
     await sleep(100);
     expect(2).toBe(2);
     console.log('concurrent: test b complete.');
   });
+
   it.concurrent('c', async () => {
     await sleep(100);
     expect(3).toBe(3);
@@ -51,11 +59,13 @@ describe('sequential suite', () => {
     expect(1).toBe(1);
     console.log('sequential: test a complete.');
   });
+
   it.sequential('b', async () => {
     await sleep(100);
     expect(2).toBe(2);
     console.log('sequential: test b complete.');
   });
+
   it.sequential('c', async () => {
     await sleep(100);
     expect(3).toBe(3);

--- a/test/concurrent.test.ts
+++ b/test/concurrent.test.ts
@@ -1,0 +1,64 @@
+/* eslint-disable no-console */
+
+// https://pc.atsuhiro-me.net/entry/2022/02/28/163920
+
+//
+// NOTE:
+// `vitest run --silent`: Silent console output from tests
+//
+
+// eslint-disable-next-line no-promise-executor-return
+const sleep = (t: number) => new Promise((resolve) => setTimeout(resolve, t));
+
+beforeAll(async () => {
+  await sleep(100);
+  console.log('beforeAll() complete.');
+});
+afterAll(async () => {
+  await sleep(100);
+  console.log('afterAll() complete.');
+});
+beforeEach(async () => {
+  await sleep(100);
+  console.log('beforeEach() complete.');
+});
+afterEach(async () => {
+  await sleep(100);
+  console.log('afterEach() complete.');
+});
+
+describe('concurrent suite', () => {
+  it.concurrent('a', async () => {
+    await sleep(100);
+    expect(1).toBe(1);
+    console.log('concurrent: test a complete.');
+  });
+  it.concurrent('b', async () => {
+    await sleep(100);
+    expect(2).toBe(2);
+    console.log('concurrent: test b complete.');
+  });
+  it.concurrent('c', async () => {
+    await sleep(100);
+    expect(3).toBe(3);
+    console.log('concurrent: test c complete.');
+  });
+});
+
+describe('sequential suite', () => {
+  it.sequential('a', async () => {
+    await sleep(100);
+    expect(1).toBe(1);
+    console.log('sequential: test a complete.');
+  });
+  it.sequential('b', async () => {
+    await sleep(100);
+    expect(2).toBe(2);
+    console.log('sequential: test b complete.');
+  });
+  it.sequential('c', async () => {
+    await sleep(100);
+    expect(3).toBe(3);
+    console.log('sequential: test c complete.');
+  });
+});

--- a/test/domByDefineProperty.test.ts
+++ b/test/domByDefineProperty.test.ts
@@ -1,0 +1,58 @@
+const redirectFromExample = () => {
+  const { hostname, search } = window.location;
+  const redirectHostname = hostname === 'example.com' ? 'www.google.com' : hostname;
+  window.location.href = `//${redirectHostname}${search}`;
+};
+
+const setupWindow = () => {
+  global.window = Object.create(null);
+  Object.defineProperty(window, 'location', {
+    value: {
+      hostname: '',
+      href: '',
+      pathname: '/',
+      search: '',
+    },
+    writable: true,
+  });
+};
+
+describe('redirectFromExample', () => {
+  it('redirect to google.com from example', () => {
+    expect.assertions(1);
+
+    setupWindow();
+
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: 'example.com',
+        href: 'https://example.com/',
+        pathname: '/',
+        search: '',
+      },
+    });
+
+    redirectFromExample();
+
+    expect(window.location.href).toBe('//www.google.com');
+  });
+
+  it('not redirect to google.com', () => {
+    expect.assertions(1);
+
+    setupWindow();
+
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: 'www.yahoo.jp',
+        href: 'https://www.yahoo.jp/',
+        pathname: '/',
+        search: '?hoge=text',
+      },
+    });
+
+    redirectFromExample();
+
+    expect(window.location.href).toBe('//www.yahoo.jp?hoge=text');
+  });
+});

--- a/test/mock.test.ts
+++ b/test/mock.test.ts
@@ -1,5 +1,3 @@
-import { expect, test, vi } from 'vitest';
-
 describe('vi.fn', () => {
   test.concurrent('spy function no arguments and no returns', () => {
     // Define mock function

--- a/test/mock.test.ts
+++ b/test/mock.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, vi } from 'vitest';
 
 describe('vi.fn', () => {
-  test('spy function no arguments and no returns', () => {
+  test.concurrent('spy function no arguments and no returns', () => {
     // Define mock function
     const getApples = vi.fn();
     // call mock function
@@ -10,7 +10,7 @@ describe('vi.fn', () => {
     expect(getApples).toHaveBeenCalled();
   });
 
-  test('spy function returns a product', () => {
+  test.concurrent('spy function returns a product', () => {
     const getProduct = vi.fn((product: string) => ({ product }));
 
     getProduct('apples');
@@ -20,7 +20,7 @@ describe('vi.fn', () => {
 });
 
 describe('mock.calls and mock.results', () => {
-  test('sample test', () => {
+  test.concurrent('sample test', () => {
     const fn = vi.fn();
 
     fn('hello', 1);
@@ -41,7 +41,7 @@ describe('spyOn', () => {
     getApples: () => 4,
   };
 
-  test('spy method', () => {
+  test.concurrent('spy method', () => {
     // Define mock method
     const spy = vi.spyOn(cart1, 'getApples');
     // call mock method
@@ -55,7 +55,7 @@ describe('spyOn', () => {
     getApples: () => 4,
   };
 
-  test('overwrite spy method', () => {
+  test.concurrent('overwrite spy method', () => {
     const spy = vi.spyOn(cart2, 'getApples').mockImplementation(() => 8);
     cart2.getApples();
     expect(spy).toHaveReturnedWith(8);

--- a/test/mock.test.ts
+++ b/test/mock.test.ts
@@ -24,7 +24,7 @@ describe('mock.calls and mock.results', () => {
     fn('hello', 1);
 
     expect(vi.isMockFunction(fn)).toBe(true);
-    expect(fn.mock.calls[0]).toEqual(['hello', 1]);
+    expect(fn.mock.calls[0]).toStrictEqual(['hello', 1]);
 
     fn.mockImplementation((arg: string) => arg);
 

--- a/test/sum.test.ts
+++ b/test/sum.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 import sum from '../src/sum';
 
-test('adds 1 + 2 to equal 3', () => {
+test.concurrent('adds 1 + 2 to equal 3', () => {
   expect(sum(1, 2)).toBe(3);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,9 @@
 
     // Specify type package names to be included without being referenced in a source file.
     "types": [
+      // TSC cannot find name of Global Object
+      // https://stackoverflow.com/a/45446470
+      "node",
       // https://vitest.dev/config/#globals
       "vitest/globals"
     ],


### PR DESCRIPTION
## Summary
- Add README.md with Docker environment setup instructions
- Add comprehensive Vitest test examples (async, concurrent, mock, DOM)
- Update .gitignore to exclude local environment files (Dockerfile, docker-entrypoint.sh)
- Add @types/node for TypeScript support
- Configure tsconfig for Vitest globals

## Test plan
- [ ] Run `vitest run --silent` to verify all tests pass
- [ ] Verify README setup instructions are clear and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)