### PR TITLE
Add Dependabot config and update Dockerfile.dev references

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    target-branch: "develop"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    target-branch: "develop"
+    versioning-strategy: increase
+    groups:
+      eslint:
+        patterns:
+          - "eslint"
+          - "@stylistic/eslint-plugin"
+          - "typescript-eslint"
+      typescript:
+        patterns:
+          - "typescript"
+          - "@types/node"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /node_modules/
 docker-entrypoint.sh
-Dockerfile
+Dockerfile.dev

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Please download the required files by following these steps:
 
 ```
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/heads/main/Dockerfile
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/heads/main/docker-entrypoint.sh
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.2.1/Dockerfile.dev
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.2.1/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` to automate dependency updates for npm and GitHub Actions ecosystems
  - Weekly schedule (Monday), targeting `develop` branch
  - ESLint-related and TypeScript-related packages are grouped for coordinated updates
  - `versioning-strategy: increase` to update `package.json` ranges, not just the lockfile
- Update `.gitignore` to ignore `Dockerfile.dev` instead of `Dockerfile`
- Update `README.md` to reference tagged `Dockerfile.dev` download URLs

## Test plan

- [ ] Verify Dependabot registers the repository on GitHub Settings > Code security
- [ ] Confirm Dependabot PRs are created targeting `develop` within 24 hours
- [ ] Verify CI workflows (`test`, `reviewdog`, `safe-chain`) run on Dependabot PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)