### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,13 +11,13 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
           cache: 'npm'
       - run: npm ci
-      - uses: reviewdog/action-eslint@v1
+      - uses: reviewdog/action-eslint@556a3fdaf8b4201d4d74d406013386aa4f7dab96 # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review

--- a/.github/workflows/safe-chain.yml
+++ b/.github/workflows/safe-chain.yml
@@ -10,9 +10,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
       - name: Setup safe-chain

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
           cache: 'npm'


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references from version tags (`@v4`, `@v1`) to full commit SHAs across all 3 workflows (`test.yml`, `reviewdog.yml`, `safe-chain.yml`)
- Version tag is preserved as an inline comment (e.g., `@34e11487... # v4`) for readability
- Enables Dependabot to automatically update SHAs, improving supply chain security

## Test plan

- [ ] Verify CI workflows still pass with SHA-pinned actions
- [ ] Confirm Dependabot detects and proposes SHA updates when new action versions are released

🤖 Generated with [Claude Code](https://claude.com/claude-code)