### PR TITLE
Clean up VSCode settings and remove Copilot extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -28,8 +28,6 @@
     "dbankier.vscode-quick-select",
     // https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens
     "eamodio.gitlens",
-    // https://marketplace.visualstudio.com/items?itemName=GitHub.copilot
-    "GitHub.copilot",
     // https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github
     "GitHub.vscode-pull-request-github",
     // https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,16 +20,14 @@
     "editor.formatOnSave": false
   },
 
-  // To actually start using the workspace version for IntelliSense,
-  // you **MUST RUN** the TypeScript: Select TypeScript Version command
-  // and select the workspace version.
+  // Use the workspace-installed TypeScript for IntelliSense.
   // https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-newer-typescript-versions
-  "typescript.tsdk": "./node_modules/typescript/lib",
+  "js/ts.tsdk.path": "./node_modules/typescript/lib",
 
   // https://code.visualstudio.com/docs/typescript/typescript-editing
-  "typescript.implementationsCodeLens.enabled": true,
-  "typescript.referencesCodeLens.enabled": true,
-  "typescript.suggest.autoImports": true,
+  "js/ts.implementationsCodeLens.enabled": true,
+  "js/ts.referencesCodeLens.enabled": true,
+  "js/ts.suggest.autoImports": true,
 
   //
   // ESLint


### PR DESCRIPTION
## Summary
- Remove GitHub Copilot from recommended extensions in `.vscode/extensions.json`
- Migrate VSCode TypeScript settings from deprecated `typescript.*` keys to the new `js/ts.*` keys and simplify the comment

## Test plan
- [ ] Verify VSCode IntelliSense still works with the new `js/ts.tsdk.path` setting
- [ ] Confirm recommended extensions list no longer includes GitHub Copilot

🤖 Generated with [Claude Code](https://claude.com/claude-code)